### PR TITLE
mix smuggle encode <filename.exs>

### DIFF
--- a/lib/config_smuggler.ex
+++ b/lib/config_smuggler.ex
@@ -58,6 +58,9 @@ defmodule ConfigSmuggler do
   * `encode_statement/1` converts a single `config` statement from a
     `config.exs`-style file into an encoded config map.
 
+  * At the command line, `mix smuggle encode <filename.exs>` encodes
+    a file with `encode_file/1` and emits a JSON object as output.
+
   ## Encoding Scheme
 
   The encoded key begins with `elixir` and is a hyphen-separated "path"

--- a/lib/mix/tasks/smuggle.ex
+++ b/lib/mix/tasks/smuggle.ex
@@ -1,0 +1,33 @@
+defmodule Mix.Tasks.Smuggle do
+  @moduledoc ~S"""
+  ConfigSmuggler provides the `mix smuggle` task, which encodes
+  `config.exs`-style files into JSON-formatted key/value pairs.
+
+  Usage: `mix smuggle encode <filename.exs>`
+  """
+  use Mix.Task
+
+  @impl true
+  @shortdoc "Encodes a config.exs-style file into JSON keys and values"
+  def run(["encode", filename]) do
+    with {:ok, encoded_config_map} <- ConfigSmuggler.encode_file(filename) do
+      IO.puts("{")
+
+      encoded_config_map
+      |> Enum.map(fn {k,v} -> "  #{inspect(k)}: #{inspect(v)}" end)
+      |> Enum.join(",\n")
+      |> IO.puts
+
+      IO.puts("}")
+    else
+      {:error, reason} ->
+        Mix.shell.error("Error: #{inspect(reason)}")
+        System.halt(1)
+    end
+  end
+
+  def run(_args) do
+    Mix.shell.error("Usage: mix smuggle encode <filename.exs>")
+    System.halt(1)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,8 @@ defmodule ConfigSmuggler.MixProject do
 
   defp deps do
     [
+      {:jason, "~> 1.0", optional: true},
+      {:poison, "~> 1.0", optional: true},
       {:freedom_formatter, "~> 1.0", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0.0-rc.4", only: :dev, runtime: false},
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -4,7 +4,9 @@
   "erlex": {:hex, :erlex, "0.2.1", "cee02918660807cbba9a7229cae9b42d1c6143b768c781fa6cee1eaf03ad860b", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "freedom_formatter": {:hex, :freedom_formatter, "1.0.0", "b19be4a845082d05d32bb23765e8e7bdc6d51decac13ab64ae44b0f6bf8a66d1", [:mix], [], "hexpm"},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "poison": {:hex, :poison, "1.5.2", "560bdfb7449e3ddd23a096929fb9fc2122f709bcc758b2d5d5a5c7d0ea848910", [:mix], [], "hexpm"},
 }

--- a/test/config_smuggler_test.exs
+++ b/test/config_smuggler_test.exs
@@ -21,10 +21,11 @@ defmodule ConfigSmugglerTest do
       {app,
        [
          {:some_key, :some_value},
-         {Some.Module, [
-             other_key: "other value",
-             deep_key: :deep_value,
-           ]},
+         {Some.Module,
+          [
+            other_key: "other value",
+            deep_key: :deep_value,
+          ]},
        ]},
     ]
 
@@ -97,19 +98,21 @@ defmodule ConfigSmugglerTest do
   describe "encode/1" do
     test "encodes native configs", context do
       assert({:ok, config_map} = ConfigSmuggler.encode(context.decoded_configs))
+
       config_map_without_errors =
         context.errors
-        |> Enum.reduce(context.encoded_config_map, fn ({{k,_v},_e}, acc) ->
+        |> Enum.reduce(context.encoded_config_map, fn {{k, _v}, _e}, acc ->
           Map.delete(acc, k)
         end)
+
       assert(config_map == config_map_without_errors)
     end
 
     test "handles bad inputs" do
       assert({:error, :bad_input} = ConfigSmuggler.encode("blorp"))
-      assert({:error, :bad_input} = ConfigSmuggler.encode(22/7))
+      assert({:error, :bad_input} = ConfigSmuggler.encode(22 / 7))
       assert({:error, :bad_input} = ConfigSmuggler.encode([1, 2, 3]))
-      assert({:error, :bad_input} = ConfigSmuggler.encode([a: :b]))
+      assert({:error, :bad_input} = ConfigSmuggler.encode(a: :b))
       assert({:error, :bad_input} = ConfigSmuggler.encode(%{}))
     end
 
@@ -117,13 +120,20 @@ defmodule ConfigSmugglerTest do
       configs = [
         ex_aws: [
           access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :instance_role],
-          secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role],
-        ]
+          secret_access_key: [
+            {:system, "AWS_SECRET_ACCESS_KEY"},
+            :instance_role,
+          ],
+        ],
       ]
+
       config_map = %{
-        "elixir-ex_aws-access_key_id" => "[{:system, \"AWS_ACCESS_KEY_ID\"}, :instance_role]",
-        "elixir-ex_aws-secret_access_key" => "[{:system, \"AWS_SECRET_ACCESS_KEY\"}, :instance_role]",
+        "elixir-ex_aws-access_key_id" =>
+          "[{:system, \"AWS_ACCESS_KEY_ID\"}, :instance_role]",
+        "elixir-ex_aws-secret_access_key" =>
+          "[{:system, \"AWS_SECRET_ACCESS_KEY\"}, :instance_role]",
       }
+
       assert({:ok, config_map} == ConfigSmuggler.encode(configs))
     end
   end
@@ -138,20 +148,27 @@ defmodule ConfigSmugglerTest do
         "elixir-config_smuggler-ConfigSmuggler-kwlist-yes" => "true",
         "elixir-config_smuggler-ConfigSmuggler-kwlist-no" => "false",
       }
+
       assert({:ok, config_map} == ConfigSmuggler.encode_file("config/test.exs"))
     end
 
     test "returns errors on broken input" do
       assert({:error, :load_error} = ConfigSmuggler.encode_file("nope.txt"))
       assert({:error, :bad_input} = ConfigSmuggler.encode_file("README.md"))
-      assert({:error, :bad_input} = ConfigSmuggler.encode_file("assets/smuggler.jpg"))
+
+      assert(
+        {:error, :bad_input} = ConfigSmuggler.encode_file("assets/smuggler.jpg")
+      )
     end
   end
 
   describe "encode_statement/1" do
     test "returns errors on broken input" do
       assert({:error, :bad_input} = ConfigSmuggler.encode_statement(:nope))
-      assert({:error, :bad_input} = ConfigSmuggler.encode_statement("config wat"))
+
+      assert(
+        {:error, :bad_input} = ConfigSmuggler.encode_statement("config wat")
+      )
     end
   end
 end


### PR DESCRIPTION
This PR adds the `mix smuggle` task, which currently can be used to encode a `config.exs`-style file into JSON-formatted keys and values at the command line.