### PR TITLE
Fix keyword list detection in `encode/1`

### DIFF
--- a/lib/config_smuggler/encoder.ex
+++ b/lib/config_smuggler/encoder.ex
@@ -6,18 +6,26 @@ defmodule ConfigSmuggler.Encoder do
   """
   @spec encode_app_path_and_opts(atom, [atom], Keyword.t()) ::
           [{ConfigSmuggler.encoded_key(), ConfigSmuggler.encoded_value()}]
-  def encode_app_path_and_opts(app, path, opts) when is_list(opts) do
-    Enum.flat_map(opts, fn {key, value} ->
-      case value do
-        [{_k, _v} | _] -> encode_app_path_and_opts(app, path ++ [key], value)
-        _ -> [{encode_key([app] ++ path ++ [key]), encode_value(value)}]
-      end
-    end)
+  def encode_app_path_and_opts(app, path, opts) do
+    if is_keyword_list?(opts) do
+      Enum.flat_map(opts, fn {key, value} ->
+        case value do
+          [{_k, _v} | _] -> encode_app_path_and_opts(app, path ++ [key], value)
+          _ -> [{encode_key([app] ++ path ++ [key]), encode_value(value)}]
+        end
+      end)
+    else
+      [{encode_key([app | path]), encode_value(opts)}]
+    end
   end
 
-  def encode_app_path_and_opts(app, path, value) do
-    [{encode_key([app | path]), encode_value(value)}]
+  defp is_keyword_list?([]), do: true
+
+  defp is_keyword_list?([{k, _v} | rest]) when is_atom(k) do
+    is_keyword_list?(rest)
   end
+
+  defp is_keyword_list?(_), do: false
 
   @doc ~S"""
   Returns an encoded key using the given parts (atoms and

--- a/test/config_smuggler_test.exs
+++ b/test/config_smuggler_test.exs
@@ -112,6 +112,20 @@ defmodule ConfigSmugglerTest do
       assert({:error, :bad_input} = ConfigSmuggler.encode([a: :b]))
       assert({:error, :bad_input} = ConfigSmuggler.encode(%{}))
     end
+
+    test "handles kwlist fakeouts" do
+      configs = [
+        ex_aws: [
+          access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :instance_role],
+          secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role],
+        ]
+      ]
+      config_map = %{
+        "elixir-ex_aws-access_key_id" => "[{:system, \"AWS_ACCESS_KEY_ID\"}, :instance_role]",
+        "elixir-ex_aws-secret_access_key" => "[{:system, \"AWS_SECRET_ACCESS_KEY\"}, :instance_role]",
+      }
+      assert({:ok, config_map} == ConfigSmuggler.encode(configs))
+    end
   end
 
   describe "encode_file/1" do


### PR DESCRIPTION
This PR improves kwlist detection so that certain configs that look vaguely like keyword lists don't barf out with `:bad_input`.